### PR TITLE
Update requirements.txt for Langchain Community

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ langgraph
 pymupdf
 html2text
 langchain-aws
-langchain-community
+langchain-community>=0.2.5
 langchain-experimental==0.0.61
 httpx


### PR DESCRIPTION
*Issue #, if available:*
```
ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
    langchain-community from https://files.pythonhosted.org/packages/d2/27/9c310c60c572b69a8eeb27f828b0df097834062862f541128b02b87df8f0/langchain_community-0.2.5-py3-none-any.whl#sha256=bf37a334952e42c7676d083cf2d2c4cbfbb7de1949c4149fe19913e2b06c485f (from -r requirements.txt (line 7)):
        Expected sha256 bf37a334952e42c7676d083cf2d2c4cbfbb7de1949c4149fe19913e2b06c485f
             Got        6ce1d2443c030a09305f281984ea83e306f348d10791e1135a0a4dced8b63c7e
```
*Description of changes:*
I updated to use lower version compatible with the rest of the requirements file until this scary one is fixed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
